### PR TITLE
clockwork doesn't use jargon, remove the dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -30,9 +30,6 @@
                  [com.mchange/c3p0 "0.9.5.1"]
                  [korma "0.3.0-RC5"
                   :exclusions [c3p0]]
-                 [org.cyverse/clj-jargon "2.8.0"
-                   :exclusions [[org.slf4j/slf4j-log4j12]
-                                [log4j]]]
                  [org.cyverse/clojure-commons "2.8.0"]
                  [org.cyverse/common-cli "2.8.0"]
                  [org.cyverse/kameleon "2.8.0"]

--- a/src/clockwork/config.clj
+++ b/src/clockwork/config.clj
@@ -1,7 +1,6 @@
 (ns clockwork.config
   (:use [slingshot.slingshot :only [throw+]])
-  (:require [clj-jargon.init :as jargon]
-            [clojure-commons.config :as cc]
+  (:require [clojure-commons.config :as cc]
             [clojure-commons.error-codes :as ce]))
 
 (def ^:private props
@@ -113,9 +112,3 @@
   (cc/load-config-from-file cfg-path props)
   (cc/log-config props)
   (validate-config))
-
-(defn jargon-config
-  "Obtains a Jargon configuration map."
-  []
-  (jargon/init (irods-host) (irods-port) (irods-user) (irods-password) (irods-home) (irods-zone)
-               (irods-resource)))


### PR DESCRIPTION
(and the one place that imports it, which is just for creating a config that never gets used)
