### PR TITLE
CORE-8421 Remove kameleon dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -34,7 +34,6 @@
                  [org.cyverse/clojure-commons "2.8.0"]
                  [org.cyverse/common-cli "2.8.0"]
                  [org.cyverse/event-messages "0.0.1"]
-                 [org.cyverse/kameleon "2.8.0"]
                  [org.cyverse/service-logging "2.8.0"]
                  [me.raynes/fs "1.4.6"]
                  [slingshot "0.10.3"]]

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
       (string/trim (:out (sh "git" "rev-parse" "HEAD")))
       ""))
 
-(defproject org.cyverse/clockwork "2.8.1-SNAPSHOT"
+(defproject org.cyverse/clockwork "2.10.0-SNAPSHOT"
   :description "Scheduled jobs for the CyVerse Discovery Environment"
   :url "https://github.com/cyverse-de/clockwork"
   :license {:name "BSD"

--- a/src/clockwork/notifications.clj
+++ b/src/clockwork/notifications.clj
@@ -1,8 +1,7 @@
 (ns clockwork.notifications
   (:use [clj-time.core :only [days minus now]]
-        [korma.core]
-        [korma.db]
-        [kameleon.notification-entities])
+        [korma.core :exclude [update]]
+        [korma.db])
   (:require [clockwork.config :as config]
             [clojure.java.jdbc :as jdbc]
             [clojure.tools.logging :as log])
@@ -50,7 +49,7 @@
 (defn- delete-notifications
   "Removes old notifications from the database."
   [cleanup-age]
-  (delete notifications
+  (delete :notifications
           (where {:date_created [< cleanup-age]})))
 
 (defn clean-up-old-notifications


### PR DESCRIPTION
The `kameleon.notification-entities` namespace was moved to `notification-agent.db.entities` for cyverse-de/kameleon#6 and clockwork does not need to use entities in its korma queries.