### PR TITLE
Add a job that triggers data-usage-api reindexing every N hours (default 3)

### DIFF
--- a/src/clockwork/config.clj
+++ b/src/clockwork/config.clj
@@ -65,6 +65,21 @@
   [props config-valid configs]
   "clockwork.jobs.infosquito.indexing-enabled" true)
 
+(cc/defprop-optstr data-usage-api-job-basename
+  "Basename of data-usage-api indexing task."
+  [props config-valid configs]
+  "clockwork.jobs.data-usage-api.basename" "data-usage.1")
+
+(cc/defprop-optint data-usage-api-interval
+  "Numeric number of hours for the interval between data-usage-api indexing"
+  [props config-valid configs]
+  "clockwork.jobs.data-usage-api.interval" 3)
+
+(cc/defprop-optboolean data-usage-api-indexing-enabled
+  "Indicates whether data-usage-api indexing tasks are enabled."
+  [props config-valid configs]
+  "clockwork.jobs.data-usage-api.indexing-enabled" true)
+
 (cc/defprop-optstr amqp-uri
   "The URI to use to establish AMQP connections."
   [props config-valid configs]


### PR DESCRIPTION
Late night PR but I realized adding this to clockwork was probably pretty easy.

This will make it so data-usage-api recalculation happens every 3 hours, not just weekly + on demand when data is more than 3 hours old. May want to add data cleanup/streamlining process to data-usage-api eventually (to get rid of having huge numbers of equal readings in the DB), but I'm not sure it matters until we're having issues.

The weekly one will still happen, so that'll be an extra one on top of the 3-hour interval ones.